### PR TITLE
メッセージにバリデーションをかける

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,14 +1,15 @@
 class MessagesController < ApplicationController
   def index
     @chat_messages = Group.find(params[:group_id]).messages.includes(:user).order(created_at: :asc)
-    # binding.pry
     @chat_message = Message.new(group_id: params[:group_id])
-    # binding.pry
   end
 
   def create
-    Message.create(message_params)
-    redirect_to action: :index
+    if Message.create(message_params).valid?
+      redirect_to group_messages_path
+    else
+      redirect_to group_messages_path, alert: 'メッセージを入力してください。'
+    end
   end
 
   private

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -2,5 +2,6 @@ class Message < ApplicationRecord
   belongs_to :group
   belongs_to :user
   mount_uploader :image, MessageImageUploader
-  # validates :image, presence: true, unless: Proc.new { |a| a.body.present? }
+  validates :image, presence: true, unless: Proc.new { |a| a.body.present? }
+  # validates :body, presence: true
 end


### PR DESCRIPTION
# What
バリデーションの実装。

# Why
データベースにメッセージと画像の両方が空の場合、登録できないようにする。
空の情報があると何もないメッセージが表示されるてしまうことを未然に防ぐ。