### PR TITLE
メッセージ非同期送信の実装

### DIFF
--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,0 +1,25 @@
+$(function () {
+  $('#new_message').on('submit', function (e) {
+    e.preventDefault();
+    //console.log('OK');
+    // create form data
+    var formData = new FormData(this);
+    var url = $(this).attr('action');
+    // debugger;
+    $.ajax({
+      url: url,
+      type: 'POST',
+      data: formData,
+      processData: false,
+      contentType: false,
+      dataType: 'json',
+    })
+    .done(function(data) {
+      console.log('OK')
+    })
+    .fail(function () {
+      alert('Fail!!')
+    })
+
+  })
+})

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,25 +1,86 @@
 $(function () {
-  $('#new_message').on('submit', function (e) {
-    e.preventDefault();
-    //console.log('OK');
-    // create form data
-    var formData = new FormData(this);
-    var url = $(this).attr('action');
-    // debugger;
-    $.ajax({
-      url: url,
-      type: 'POST',
-      data: formData,
-      processData: false,
-      contentType: false,
-      dataType: 'json',
-    })
-    .done(function(data) {
-      console.log('OK')
-    })
-    .fail(function () {
-      alert('Fail!!')
-    })
 
+  // return image html
+  function image_html(data) {
+      return `<img src="${data.image.url}" alt="${data.image_alt}">`;
+  }
+
+  // return image thumb html
+  function image_thumb_html(data) {
+    return `<img src="${data.image.thumb.url}" alt="${data.image_thumb_alt}">`;
+  }
+
+  // return main contents html
+  function buildMainHTML(data) {
+    html = `<div class="chat-message-container">
+              <div class="chat-message__info">
+                <p class="chat-message__username">${data.username}</p>
+                <p class="chat-message__date">${data.date}</p>
+              </div>
+              <div class="chat-message__message">
+                <p>${data.message}</p>
+                ${data.image.url ? image_html(data) : ''}
+              </div>
+            </div>`;
+    
+    return html;
+  }
+
+  // return side contents html
+  function buildSideHTML(data) {
+    var html = `<div class="chat-group__info">`;
+    if (data.message) {
+      html = html + `${data.message} `
+    }
+    if (data.image.url) {
+      html = html + `${image_thumb_html(data)}`
+    }
+    return html + `</div>`
+  }
+
+  function getCurSideGroup(url) {
+    var chat_groups = $(".chat-group a");
+    for (var i = 0; i < chat_groups.length; i++){
+      if ($(chat_groups[i]).attr('href') === url) return $(chat_groups[i]);
+    }
+  }
+
+  // run turbolinks event at first load, reload, page switching
+  $(document).on('turbolinks:load', function () {
+    // run ajax
+    $('#new_message').on('submit', function (e) {
+      e.preventDefault();
+
+      var formData = new FormData(this);
+      var url = $(this).attr('action');
+
+      $.ajax({
+        url: url,
+        type: 'POST',
+        data: formData,
+        dataType: "json",
+        processData: false,
+        contentType: false
+      })
+        .done(function (data) {
+          // update main contents
+          $(".contents__chat-messages")
+            .append(buildMainHTML(data))
+            .animate({ scrollTop: $(".contents__chat-messages")[0].scrollHeight });
+          $("#message_body").val('');
+          $(".chat-form__btn").prop("disabled", false);
+          // update sidebar
+          var side_group = getCurSideGroup(url);
+          side_group.find(".chat-group__info").remove();
+          side_group.append(buildSideHTML(data));
+          console.log('OK');
+          // debugger;
+        })
+        .fail(function () {
+          alert('メッセージの送信に失敗しました')
+        })
+
+    })
   })
+
 })

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -38,7 +38,8 @@ $(function () {
     return html + `</div>`
   }
 
-  function getCurSideGroup(url) {
+  // return current chose group on sidebar for jquery
+  function getCurrentSideGroup(url) {
     var chat_groups = $(".chat-group a");
     for (var i = 0; i < chat_groups.length; i++){
       if ($(chat_groups[i]).attr('href') === url) return $(chat_groups[i]);
@@ -62,23 +63,23 @@ $(function () {
         processData: false,
         contentType: false
       })
-        .done(function (data) {
-          // update main contents
-          $(".contents__chat-messages")
-            .append(buildMainHTML(data))
-            .animate({ scrollTop: $(".contents__chat-messages")[0].scrollHeight });
-          $("#message_body").val('');
-          $(".chat-form__btn").prop("disabled", false);
-          // update sidebar
-          var side_group = getCurSideGroup(url);
-          side_group.find(".chat-group__info").remove();
-          side_group.append(buildSideHTML(data));
-          console.log('OK');
-          // debugger;
-        })
-        .fail(function () {
-          alert('メッセージの送信に失敗しました')
-        })
+      .done(function (data) {
+        // update main contents
+        $(".contents__chat-messages")
+          .append(buildMainHTML(data))
+          .animate({ scrollTop: $(".contents__chat-messages")[0].scrollHeight });
+        $("#message_body").val('');
+        $('#message_image').val('');
+        $(".chat-form__btn").prop("disabled", false);
+        // update sidebar
+        var side_group = getCurrentSideGroup(url);
+        side_group.find(".chat-group__info").remove();
+        side_group.append(buildSideHTML(data));
+      })
+      .fail(function () {
+        alert('メッセージの送信に失敗しました');
+        $(".chat-form__btn").prop("disabled", false);
+      })
 
     })
   })

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -68,8 +68,7 @@ $(function () {
         $(".contents__chat-messages")
           .append(buildMainHTML(data))
           .animate({ scrollTop: $(".contents__chat-messages")[0].scrollHeight });
-        $("#message_body").val('');
-        $('#message_image').val('');
+        $('#new_message')[0].reset();
         $(".chat-form__btn").prop("disabled", false);
         // update sidebar
         var side_group = getCurrentSideGroup(url);

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -8,12 +8,18 @@ class MessagesController < ApplicationController
 
   def create
     @chat_message = @group.messages.new(message_params)
-    if @chat_message.save
-      redirect_to group_messages_path, notice: 'メッセージが送信されました'
-    else
-      @chat_messages = @group.messages.includes(:user)
-      flash.now[:alert] = 'メッセージを入力してください。'
-      render :index
+    respond_to do |format|
+      if @chat_message.save
+        format.html { redirect_to group_messages_path, notice: 'メッセージが送信されました' }
+        format.json
+      else
+        format.html {
+          @chat_messages = @group.messages.includes(:user)
+          flash.now[:alert] = 'メッセージを入力してください。'
+          render :index
+        }
+        format.json
+      end
     end
   end
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -2,7 +2,5 @@ class Message < ApplicationRecord
   belongs_to :group
   belongs_to :user
   mount_uploader :image, MessageImageUploader
-  # Add my statement
-  # validates :image, presence: true, unless: Proc.new { |a| a.body.present? }
   validates :body, presence: true, unless: :image?
 end

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,9 @@
+json.message   @chat_message.body
+json.username  @chat_message.user.name
+json.date      @chat_message.created_at.strftime("%Y/%m/%d(%a) %H:%M:%S")
+json.image     @chat_message.image
+
+unless @chat_message.image.file.nil?
+  json.image_alt @chat_message.image.filename.split(".")[0]
+  json.image_thumb_alt File::basename(@chat_message.image.thumb.url).split(".")[0]
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  # config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
 
   factory :message do
     body       {Faker::Lorem.sentence}
-    # image      {Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/test.jpg'), 'image/jpeg')}
     image {File.open("#{Rails.root}/spec/fixtures/test.jpg")}
     created_at {Faker::Time.between(2.days.ago, Time.now, :all)}
     group

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,15 +1,10 @@
 FactoryBot.define do
 
   factory :user do
-    # email      {"testAAA@testAAA.local"}
-    # password   {"00000000"}
-    # created_at {Faker::Time.between(2.days.ago, Time.now, :all)}
-    # name       {'test_user'}
     password = Faker::Internet.password(8)
     name {Faker::Name.last_name}
     email {Faker::Internet.free_email}
     password {password}
-    # password_confirmation {password}
   end
 
 end


### PR DESCRIPTION
# What
メッセージを画面のリロード無し（非同期）で送信できるようにする。

# Why
現状、メッセージを送信するたびにリダイレクト処理が発生しチャットのリアルタイム性が実現できていないため。